### PR TITLE
[ci skip] Remove channels from conda-forge.yml (for conda-smithy 3.28.0)

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,6 +11,3 @@ test_on_native_only: true
 conda_build:
   pkg_format: '2'
 upload_on_branch: main
-channels:
-  targets:
-    - ["tiledb", "main"]


### PR DESCRIPTION
Please squash and merge to avoid running CI post-merge (I don't have write access)