### PR TITLE
Add test section

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,14 +48,12 @@ requirements:
     - openblas
 
 test:
-  imports:
-    - tiledb.vector_search
-  commands:
-    - pip check
   requires:
     - pip
-    - pip:
-        - tiledb-cloud
+  commands:
+    - pip install --prefer-binary tiledb-cloud
+    - pip check
+    - python -c "import tiledb.vector_search"
 
 about:
   home: https://tiledb.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ requirements:
 
 test:
   imports:
-    - tiledb_vector_search
+    - tiledb.vector_search
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,8 @@ test:
     - pip check
   requires:
     - pip
+    - pip:
+        - tiledb-cloud
 
 about:
   home: https://tiledb.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,14 @@ requirements:
     - libopenblas
     - openblas
 
+test:
+  imports:
+    - tiledb_vector_search
+  commands:
+    - pip check
+  requires:
+    - pip
+
 about:
   home: https://tiledb.com
   license: MIT


### PR DESCRIPTION
I noticed that the Python package depends on tiledb-cloud, but tiledb-cloud isn't available as a conda binary (not from conda-forge nor tiledb channels). I was surprised that the recipe could be built, but then I realized that there is no import test.

I expect the import test will fail since [`__init__.py`](
https://github.com/TileDB-Inc/TileDB-Vector-Search/blob/bb433dbdf329b4f0f3399e946fae497fd24102c9/apis/python/src/tiledb/vector_search/__init__.py#L2) includes:

```python
from tiledb.cloud.dag.mode import Mode
```
