### PR TITLE
Increment TileDB-Vector-Search version to 0.0.20

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - scikit-build
     - libopenblas
     - openblas
+    - lz4 1.9.4 # [py==39]
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -48,6 +49,7 @@ requirements:
     - tiledb-py
     - libopenblas
     - openblas
+    - lz4 1.9.4 # [py==39]
 
 about:
   home: https://tiledb.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,6 @@ requirements:
     - scikit-build
     - libopenblas
     - openblas
-    - lz4-c 1.9.4 # [win and py==39]
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -49,7 +48,6 @@ requirements:
     - tiledb-py
     - libopenblas
     - openblas
-    - lz4-c 1.9.4 # [win and py==39]
 
 about:
   home: https://tiledb.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tiledb-vector-search" %}
-{% set version = "0.0.19" %}
+{% set version = "0.0.20" %}
 {% set sha256 = "" %}
 
 package:
@@ -35,7 +35,7 @@ requirements:
     - python
     - numpy
     - pybind11
-    - tiledb >=2.18.0,<2.19
+    - tiledb >=2.19,<2.20
     - tiledb-py
     - scikit-build
     - libopenblas
@@ -44,7 +44,7 @@ requirements:
     - python
     - {{ pin_compatible('numpy') }}
     - scikit-learn
-    - tiledb >=2.18.0,<2.19
+    - tiledb >=2.19,<2.20
     - tiledb-py
     - libopenblas
     - openblas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - scikit-build
     - libopenblas
     - openblas
-    - lz4 1.9.4 # [win and py==39]
+    - lz4-c 1.9.4 # [win and py==39]
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -49,7 +49,7 @@ requirements:
     - tiledb-py
     - libopenblas
     - openblas
-    - lz4 1.9.4 # [win and py==39]
+    - lz4-c 1.9.4 # [win and py==39]
 
 about:
   home: https://tiledb.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - scikit-build
     - libopenblas
     - openblas
-    - lz4 1.9.4 # [py==39]
+    - lz4 1.9.4 # [win and py==39]
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -49,7 +49,7 @@ requirements:
     - tiledb-py
     - libopenblas
     - openblas
-    - lz4 1.9.4 # [py==39]
+    - lz4 1.9.4 # [win and py==39]
 
 about:
   home: https://tiledb.com


### PR DESCRIPTION
Increment version of TileDB-Vector-Search to 0.0.20.

This PR still needs to wait until TileDB-Vector-Search is actually updated to this new version.