### PR TITLE
Increment version to 0.0.21

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tiledb-vector-search" %}
-{% set version = "0.0.20" %}
+{% set version = "0.0.21" %}
 {% set sha256 = "" %}
 
 package:


### PR DESCRIPTION
Increment version in recipe to 0.0.21

I believe that the underlying tiledb core version did not change so I did not change anything else.