### PR TITLE
[ci skip] Clarify source section of recipe

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ihnorton @shelnutt2
+* @ihnorton @jdblischak @shelnutt2

--- a/README.md
+++ b/README.md
@@ -238,5 +238,6 @@ Feedstock Maintainers
 =====================
 
 * [@ihnorton](https://github.com/ihnorton/)
+* [@jdblischak](https://github.com/jdblischak/)
 * [@shelnutt2](https://github.com/shelnutt2/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,12 @@
 {% set name = "tiledb-vector-search" %}
 {% set version = "0.0.21" %}
-{% set sha256 = "" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  # NOTE: using git versions so that setuptools_scm works, until we build from PyPI
-  #url: https://github.com/TileDB-Inc/feature-vector-prototype/archive/{{ version }}.tar.gz
-  #sha256: {{ sha256 }}
+  # NOTE: using git versions so that setuptools_scm works
   git_url: https://github.com/TileDB-Inc/TileDB-Vector-Search.git
   git_rev: {{ version }}
   #git_depth: 1 # (Defaults to -1/not shallow)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,3 +63,4 @@ extra:
   recipe-maintainers:
     - shelnutt2
     - ihnorton
+    - jdblischak


### PR DESCRIPTION
We are never going to be able to use PyPI as the recipe source given the current repo structure (see #22). Unless the C++ library is moved inside the Python package, it won't be uploaded to PyPI.

Our similar repos with a C++ library + Python client (eg vcf, soma) use GitHub releases as the source. This is the preferred source for Git repos for the conda-forge organization. However, this causes us headaches due to the use of setuptools-scm to generate the version of the Python package. Thus I propose we simply continue to use Git tags long term. For a TileDB-Inc owned feedstock like this where we also own the source code, a GitHub release is no more guaranteed to be stable than the underlying tag is. And [the other conda-forge concerns](https://conda-forge.org/docs/maintainer/adding_pkgs/#tarballs-no-repos) also don't really apply to the feedstocks we own (potentially using more CI time and bandwidth only negatively impacts our org and not the wider conda-forge community).

cc: @dudoslav 

(note: ~~I don't have write access so I can't self-merge~~ nevermind, it looks like I do have write-access despite not being an official maintainer of this repo)