### PR TITLE
Do not package tiledb.so

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   number: 0
-  script: TileDB_DIR=${PREFIX} {{ PYTHON }} -m pip install --no-deps --ignore-installed .
+  script: TILEDB_PATH=${PREFIX} {{ PYTHON }} -m pip install --no-deps --ignore-installed .
   skip: true # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
+  script: TileDB_DIR=${PREFIX} {{ PYTHON }} -m pip install --no-dependencies --ignore-installed .
   skip: true # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   number: 0
-  script: TileDB_DIR=${PREFIX} {{ PYTHON }} -m pip install --no-dependencies --ignore-installed .
+  script: TileDB_DIR=${PREFIX} {{ PYTHON }} -m pip install --no-deps --ignore-installed .
   skip: true # [win]
 
 requirements:


### PR DESCRIPTION
This PR should force `sdist` build to use tiledb.so installed in the conda environment instead of downloading prebuilt one from releases.