### PR TITLE
Disable build isolation during pip install

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .
   skip: true # [win]
 
 requirements:


### PR DESCRIPTION
By default `pip install` installs all the dependencies in a temporary directory, which is definitely not what we want for a conda build. Adding `--no-build-isolation` forces pip to use the dependencies installed in the conda environment. I also added the flag `-v` so it is more transparent what steps `pip install` is performing.

I didn't bump the build number. This is just an improvement that can wait until the next release.