### PR TITLE
Update vector-search to 0.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledb-vector-search" %}
-{% set version = "0.4.0" %}
-{% set sha256 = "8b10002e4f591ded84bf5cecaf9154c97985e6be36238ab1c62b0ec8334a6d0a" %}
+{% set version = "0.4.1" %}
+{% set sha256 = "0c3e00e140e97f00d4072b09e5a85eff28d2131332827d802e69741a9fbeeddd" %}
 # Pro-tip:
 # * Visit https://pypi.org/project/tiledb-vector-search/i.j.k/#files in your browser
 # * Download


### PR DESCRIPTION
### What
Updates vector-search to 0.4.1.

Release tracked [here](https://tiledb.slack.com/archives/C0537B4V7Q8/p1716280363872119).

