### PR TITLE
Add TILEDB_PATH

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .
+  script: TILEDB_PATH=${PREFIX} {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .
   skip: true # [win]
 
 requirements:


### PR DESCRIPTION
This PR should force sdist build to use tiledb.so installed in the conda environment instead of downloading prebuilt one from releases.

This PR will have full effect TileDB-Vector-Search changes including `TILEDB_PATH` logic are merged.

Note: This is recreated PR https://github.com/TileDB-Inc/tiledb-vector-search-feedstock/pull/35 with correct branch name