### PR TITLE
Only include debug info for binary deployed to TileDB Cloud

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,13 @@ source:
 
 build:
   number: 0
-  script: TILEDB_PATH=${PREFIX} {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .
+  script: TILEDB_PATH=${PREFIX} {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .  # [linux and py==39]
+  # Do not include debug info when building binaries that won't be deployed to TileDB Cloud
+  script: >-                                                # [not (linux and py==39)]
+    TILEDB_PATH=${PREFIX} {{ PYTHON }} -m pip install       # [not (linux and py==39)]
+    --no-build-isolation --no-deps --ignore-installed -v .  # [not (linux and py==39)]
+    -C skbuild.cmake.build_type="Release"                   # [not (linux and py==39)]
+    --config-settings=install.strip=true                    # [not (linux and py==39)]
   skip: true # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
   script: >-                                                # [not (linux and py==39)]
     TILEDB_PATH=${PREFIX} {{ PYTHON }} -m pip install       # [not (linux and py==39)]
     --no-build-isolation --no-deps --ignore-installed -v .  # [not (linux and py==39)]
-    -C skbuild.cmake.build_type="Release"                   # [not (linux and py==39)]
+    --config-settings=cmake.build-type="Release"            # [not (linux and py==39)]
     --config-settings=install.strip=true                    # [not (linux and py==39)]
   skip: true # [win]
 


### PR DESCRIPTION
**Background:** 

* The debug info was included in the binary starting in 0.6.0 (https://github.com/TileDB-Inc/TileDB-Vector-Search/pull/424). My understanding is that the motivation for this was for easier debugging in TileDB Cloud
* Including the debug info greatly increases the size of the binary, and thus the conda binary uploaded to anaconda.org
* We are running out of space on anaconda.org

**Proposal:**

I have attempted to use the [scikit-build-core configuration](https://scikit-build-core.readthedocs.io/en/latest/configuration.html) to override the settings in `pyproject.toml`. The goal is to only include the debug info for the binary that is installed for TileDB Cloud (linux-64 and python 3.9).

**Status:**

Unfortunately it isn't currently working. Despite passing `-C skbuild.cmake.build_type="Release" ` and `--config-settings=install.strip=true `, CMake still reports `-- Install configuration: "RelWithDebInfo"`, and the binary `_tiledbvspy.cpython-310-x86_64-linux-gnu.so` is still huge.

Can anyone see how I need to edit the `pip install` command to properly override the default settings? 