### PR TITLE
Release version 0.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - numpy
     - pybind11
     - tiledb >=2.26,<2.27
-jparismorgan/update-0.9.0    - tiledb-py
+    - tiledb-py
     - libopenblas
     - openblas
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledb-vector-search" %}
-{% set version = "0.9.0" %}
-{% set sha256 = "7091d9876ee567ff4d284b5e025a49753c033e6b2b463dcb2671b787ac8d5c00" %}
+{% set version = "0.10.0" %}
+{% set sha256 = "44256859d75771a731e2bf45ea4e27bbc77744358157bec1dc43ba96c73e9eb9" %}
 # Pro-tip:
 # * Visit https://pypi.org/project/tiledb-vector-search/i.j.k/#files in your browser
 # * Then either:
@@ -45,7 +45,7 @@ requirements:
     - numpy
     - pybind11
     - tiledb >=2.26,<2.27
-    - tiledb-py
+jparismorgan/update-0.9.0    - tiledb-py
     - libopenblas
     - openblas
   run:


### PR DESCRIPTION
### What
Release 0.10.0:
* https://github.com/TileDB-Inc/TileDB-Vector-Search/releases/tag/0.10.0
* https://pypi.org/project/tiledb-vector-search/0.10.0/
* https://anaconda.org/conda-forge/tiledb

Note that we leave `- tiledb >=2.26,<2.27` because Vector Search 0.10.0 updates from Core 2.26.0 to 2.26.1, and we leave either as options at runtime.