### PR TITLE
Manual opt-in to continue building python 3.9

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,3 +8,15 @@ channel_sources:
   - conda-forge
 channel_priority:
   - strict
+
+# Required to continue building python 3.9
+python:
+  - 3.9.* *_cpython
+  - 3.10.* *_cpython
+  - 3.11.* *_cpython
+  - 3.12.* *_cpython
+is_python_min:
+  - true
+  - false
+  - false
+  - false


### PR DESCRIPTION
xref: https://github.com/conda-forge/tiledb-py-feedstock/pull/270, #62

I didn't rerender because I don't want to introduce any other new changes. This simply keeps building the same 4 Python versions.

